### PR TITLE
OFL.txt: Standardise format

### DIFF
--- a/OFL.txt
+++ b/OFL.txt
@@ -1,7 +1,7 @@
-Mogra Gujarati + Latin | Google Web Fonts Development
-
 Copyright (c) 2015 Lipi Raval (raval.lipi@gmail.com) 
+
 This Font Software is licensed under the SIL Open Font License, Version 1.1. 
+
 This license is copied below, and is also available with a FAQ at: 
 http://scripts.sil.org/OFL 
 ----------------------------------------------------------- 


### PR DESCRIPTION
Some software parses the license files, so its good to have all the copyright notices on the first line and nothing else added to the file :) 
